### PR TITLE
Add Dockerfile for FTB Infinity version 1.7.0

### DIFF
--- a/ftb-infinity/1.7.0/Dockerfile
+++ b/ftb-infinity/1.7.0/Dockerfile
@@ -1,0 +1,19 @@
+FROM dlord/minecraft
+MAINTAINER John Paul Alcala jp@jpalcala.com
+
+ENV FTB_INFINITY_URL http://www.creeperrepo.net/FTB2/modpacks%5EFTBInfinity%5E1_7_0%5EFTBInfinityServer.zip
+ENV LAUNCHWRAPPER net/minecraft/launchwrapper/1.11/launchwrapper-1.11.jar
+
+RUN \
+    curl -S $FTB_INFINITY_URL -o /tmp/infinity.zip && \
+    unzip /tmp/infinity.zip -d $MINECRAFT_HOME && \
+    mkdir -p $MINECRAFT_HOME/libraries && \
+    curl -S https://libraries.minecraft.net/$LAUNCHWRAPPER -o $MINECRAFT_HOME/libraries/$LAUNCHWRAPPER && \
+    find $MINECRAFT_HOME -name "*.log" -exec rm -f {} \; && \
+    rm -rf $MINECRAFT_HOME/ops.* $MINECRAFT_HOME/whitelist.* $MINECRAFT_HOME/logs/* /tmp/*
+
+ENV MINECRAFT_VERSION 1.7.10
+ENV MINECRAFT_OPTS -server -Xms2048m -Xmx3072m -XX:MaxPermSize=256m -XX:+UseParNewGC -XX:+UseConcMarkSweepGC
+ENV MINECRAFT_STARTUP_JAR FTBServer-1.7.10-1448.jar
+
+VOLUME ["/opt/minecraft", "/var/lib/minecraft"]


### PR DESCRIPTION
I tried launching an FTB server with your Dockerfiles and noticed the server you have is too old and incompatible with the latest. So here's an updated Dockerfile for 1.7's FTB Infinity pack.
